### PR TITLE
Wrong equation references in the text of Monus

### DIFF
--- a/src/Naturals.lagda
+++ b/src/Naturals.lagda
@@ -522,7 +522,7 @@ _ =
      1
   ∎
 \end{code}
-We did not use the third equation at all, but it will be required
+We did not use the second equation at all, but it will be required
 if we try to subtract a smaller number from a larger one.
 \begin{code}
 _ =


### PR DESCRIPTION
In the example, the _second_ and not the _third_ equation is not used.
In fact, the third equation is used three times.