### PR TITLE
Fix operator in `∸-+-assoc` exercise

### DIFF
--- a/src/plta/Properties.lagda
+++ b/src/plta/Properties.lagda
@@ -739,7 +739,7 @@ for all naturals `n`. Did your proof require induction?
 
 Show that monus associates with addition, that is,
 
-    m ∸ n ∸ p ≡ m ∸ (n + p)
+    (m ∸ n) + p ≡ m ∸ (n + p)
 
 for all naturals `m`, `n`, and `p`.
 


### PR DESCRIPTION
The equation that shows monus associates with addition should be:

```
(m ∸ n) + p ≡ m ∸ (n + p)
```

it was previously

```
(m ∸ n) ∸ p
```

on the left hand side.